### PR TITLE
Controllers extension feature

### DIFF
--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
@@ -1,10 +1,18 @@
 package ch.hevs.gdx2d.demos.controllers;
 
+import ch.hevs.gdx2d.demos.simple.mistify.BounceShape;
 import ch.hevs.gdx2d.desktop.PortableApplication;
+import ch.hevs.gdx2d.desktop.Xbox;
 import ch.hevs.gdx2d.lib.GdxGraphics;
 import ch.hevs.gdx2d.lib.utils.Logger;
 import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.ControllerAdapter;
+import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.Controllers;
+import com.badlogic.gdx.controllers.PovDirection;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
+import com.sun.org.apache.xpath.internal.objects.XBoolean;
 
 /**
  * Demo program for the {@code controllers} extension.
@@ -16,30 +24,60 @@ public class DemoControllers extends PortableApplication {
 
   private final static String TAG = DemoControllers.class.getSimpleName();
 
+  private boolean controllersFound;
+  private int frameCnt = 0;
+  private BounceShape shape;
+  private Vector2 lastTextPos;
+
+  public static void main(String[] args) {
+    new DemoControllers();
+  }
+
   @Override
   public void onInit() {
     setTitle("Controllers demo, mei 2016");
 
-    int nbrCtrl = Controllers.getControllers().size;
-    if (nbrCtrl == 0) {
-      Logger.error(TAG, "no controller found !");
-      return;
-    }
+    shape = new BounceShape(getWindowWidth(), getWindowHeight());
 
-    Logger.log(TAG, "%d controller(s) found:", nbrCtrl);
+    controllersFound = Controllers.getControllers().size != 0;
+    Logger.log(TAG, "%d controller(s) found", Controllers.getControllers().size);
     for (Controller controller : Controllers.getControllers()) {
-      Logger.log(" - " + controller.getName());
+      Logger.log(TAG, " - " + controller.getName());
     }
   }
 
   @Override
   public void onGraphicRender(GdxGraphics g) {
     g.clear();
+
+
+
     g.drawFPS();
     g.drawSchoolLogo();
   }
 
-  public static void main(String[] args) {
-    new DemoControllers();
+  @Override
+  public void onControllerConnected(Controller controller) {
+    System.out.println("Miaou");
+  }
+
+  @Override
+  public void onControllerKeyDown(Controller controller, int buttonCode) {
+    boolean found = Xbox.isXboxController(controller);
+    if(!found) {
+      Logger.log("Xbox controller not found !");
+      return;
+    }
+
+    Logger.log("Xbox controller found !");
+    Logger.log("Button " + buttonCode + " pressed");
+
+    if(buttonCode == Xbox.X)
+      Logger.log("Button X pressed");
+  }
+
+  @Override
+  public void onControllerPovMoved(Controller controller, int povCode, PovDirection value) {
+    Logger.log("POV: " + value);
   }
 }

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
@@ -1,0 +1,45 @@
+package ch.hevs.gdx2d.demos.controllers;
+
+import ch.hevs.gdx2d.desktop.PortableApplication;
+import ch.hevs.gdx2d.lib.GdxGraphics;
+import ch.hevs.gdx2d.lib.utils.Logger;
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.Controllers;
+
+/**
+ * Demo program for the {@code controllers} extension.
+ *
+ * @author Christopher Metrailler (mei)
+ * @version 1.0
+ */
+public class DemoControllers extends PortableApplication {
+
+  private final static String TAG = DemoControllers.class.getSimpleName();
+
+  @Override
+  public void onInit() {
+    setTitle("Controllers demo, mei 2016");
+
+    int nbrCtrl = Controllers.getControllers().size;
+    if (nbrCtrl == 0) {
+      Logger.error(TAG, "no controller found !");
+      return;
+    }
+
+    Logger.log(TAG, "%d controller(s) found:", nbrCtrl);
+    for (Controller controller : Controllers.getControllers()) {
+      Logger.log(" - " + controller.getName());
+    }
+  }
+
+  @Override
+  public void onGraphicRender(GdxGraphics g) {
+    g.clear();
+    g.drawFPS();
+    g.drawSchoolLogo();
+  }
+
+  public static void main(String[] args) {
+    new DemoControllers();
+  }
+}

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/controllers/DemoControllers.java
@@ -1,18 +1,13 @@
 package ch.hevs.gdx2d.demos.controllers;
 
-import ch.hevs.gdx2d.demos.simple.mistify.BounceShape;
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.Controllers;
+import com.badlogic.gdx.controllers.PovDirection;
+
 import ch.hevs.gdx2d.desktop.PortableApplication;
 import ch.hevs.gdx2d.desktop.Xbox;
 import ch.hevs.gdx2d.lib.GdxGraphics;
 import ch.hevs.gdx2d.lib.utils.Logger;
-import com.badlogic.gdx.controllers.Controller;
-import com.badlogic.gdx.controllers.ControllerAdapter;
-import com.badlogic.gdx.controllers.ControllerListener;
-import com.badlogic.gdx.controllers.Controllers;
-import com.badlogic.gdx.controllers.PovDirection;
-import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
-import com.sun.org.apache.xpath.internal.objects.XBoolean;
 
 /**
  * Demo program for the {@code controllers} extension.
@@ -24,11 +19,6 @@ public class DemoControllers extends PortableApplication {
 
   private final static String TAG = DemoControllers.class.getSimpleName();
 
-  private boolean controllersFound;
-  private int frameCnt = 0;
-  private BounceShape shape;
-  private Vector2 lastTextPos;
-
   public static void main(String[] args) {
     new DemoControllers();
   }
@@ -37,9 +27,6 @@ public class DemoControllers extends PortableApplication {
   public void onInit() {
     setTitle("Controllers demo, mei 2016");
 
-    shape = new BounceShape(getWindowWidth(), getWindowHeight());
-
-    controllersFound = Controllers.getControllers().size != 0;
     Logger.log(TAG, "%d controller(s) found", Controllers.getControllers().size);
     for (Controller controller : Controllers.getControllers()) {
       Logger.log(TAG, " - " + controller.getName());
@@ -50,7 +37,7 @@ public class DemoControllers extends PortableApplication {
   public void onGraphicRender(GdxGraphics g) {
     g.clear();
 
-
+    //TODO: add a basic demo
 
     g.drawFPS();
     g.drawSchoolLogo();
@@ -58,7 +45,7 @@ public class DemoControllers extends PortableApplication {
 
   @Override
   public void onControllerConnected(Controller controller) {
-    System.out.println("Miaou");
+  	Logger.log("A controller has been connected !");
   }
 
   @Override

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoTurtle.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoTurtle.java
@@ -14,83 +14,83 @@ import ch.hevs.gdx2d.lib.GdxGraphics;
  * @version 1.0
  */
 public class DemoTurtle extends PortableApplication {
-	Turtle t;
+  private Turtle t;
 
-	/**
-	 * Draws the snowflake
-	 * @param length Length of the side of the flake
-	 * @param level The complexity level of the recursion
-	 */
-	void drawFlake(double length, int level) {
-		drawSegment(length, level);
-		t.turn(120);
-		drawSegment(length, level);
-		t.turn(120);
-		drawSegment(length, level);
-		t.turn(120);
-	}
+  /**
+   * Draws the snowflake
+   *
+   * @param length Length of the side of the flake
+   * @param level  The complexity level of the recursion
+   */
+  private void drawFlake(double length, int level) {
+    drawSegment(length, level);
+    t.turn(120);
+    drawSegment(length, level);
+    t.turn(120);
+    drawSegment(length, level);
+    t.turn(120);
+  }
 
-	/**
-	 * Draws a side of the flake
-	 * @param length length of the segment
-	 * @param level complexity level for the recursion
-	 */
-	void drawSegment(double length, int level) {
-		//Recursion shall end somewhere
-		if (level == 0) {
-			t.forward(length);
-			return;
-		}
+  /**
+   * Draws a side of the flake
+   *
+   * @param length length of the segment
+   * @param level  complexity level for the recursion
+   */
+  private void drawSegment(double length, int level) {
+    //Recursion shall end somewhere
+    if (level == 0) {
+      t.forward(length);
+      return;
+    }
 
-		double currentLevel = length / 3.0;
-		drawSegment(currentLevel, level - 1);
-		t.turn(-60);
-		drawSegment(currentLevel, level - 1);
-		t.turn(120);
-		drawSegment(currentLevel, level - 1);
-		t.turn(-60);
-		drawSegment(currentLevel, level - 1);
-	}
+    double currentLevel = length / 3.0;
+    drawSegment(currentLevel, level - 1);
+    t.turn(-60);
+    drawSegment(currentLevel, level - 1);
+    t.turn(120);
+    drawSegment(currentLevel, level - 1);
+    t.turn(-60);
+    drawSegment(currentLevel, level - 1);
+  }
 
-	@Override
-	public void onInit() {
-		setTitle("Moving turtle demo, mui 2016");
-	}
+  @Override
+  public void onInit() {
+    setTitle("Moving turtle demo, mui 2016");
+  }
 
-	int flakeSize = 2, animDirection = 1;
+  private int flakeSize = 2, animDirection = 1;
 
-	@Override
-	public void onGraphicRender(GdxGraphics g) {
-		if (t == null)
-			t = new Turtle(g, g.getScreenWidth(), g.getScreenHeight());
+  @Override
+  public void onGraphicRender(GdxGraphics g) {
+    if (t == null)
+      t = new Turtle(g, g.getScreenWidth(), g.getScreenHeight());
 
-		// Clears the screen
-		g.clear(Color.DARK_GRAY);
+    // Clears the screen
+    g.clear(Color.DARK_GRAY);
 
-		// Go to the top of the screen
-		t.changeColor(Color.WHITE);
+    // Go to the top of the screen
+    t.changeColor(Color.WHITE);
 
-		/**
-		 * Locate the turtle at the bottom of the screen
-		 */
-		t.penDown();
-		t.setAngle(60);
-		t.jump((float) (g.getScreenWidth() * 0.5), (float) (g.getScreenHeight() * 0.25));
+    // Move the turtle at the bottom of the screen
+    t.penDown();
+    t.setAngle(60);
+    t.jump((float) (g.getScreenWidth() * 0.5), (float) (g.getScreenHeight() * 0.25));
 
-		// Displays the snowflake
-		drawFlake(20 + flakeSize * 2, 4);
+    // Displays the snowflake
+    drawFlake(20 + flakeSize * 2, 4);
 
-		// Animate size
-		flakeSize += animDirection;
+    // Animate size
+    flakeSize += animDirection;
 
-		if (flakeSize == 100 || flakeSize == 2)
-			animDirection *= -1;
+    if (flakeSize == 100 || flakeSize == 2)
+      animDirection *= -1;
 
-		g.drawFPS();
-		g.drawSchoolLogo();
-	}
+    g.drawFPS();
+    g.drawSchoolLogo();
+  }
 
-	public static void main(String[] args) {
-		new DemoTurtle();
-	}
+  public static void main(String[] args) {
+    new DemoTurtle();
+  }
 }

--- a/gdx2d-formatter.xml
+++ b/gdx2d-formatter.xml
@@ -64,7 +64,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
 <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>

--- a/gdx2d-library/gdx2d-core/gdx2d-core.iml
+++ b/gdx2d-library/gdx2d-core/gdx2d-core.iml
@@ -14,5 +14,6 @@
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-freetype:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-box2d:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.box2dlights:box2dlights:1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-controllers:1.5.6" level="project" />
   </component>
 </module>

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/interfaces/ControllersInterface.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/interfaces/ControllersInterface.java
@@ -1,0 +1,115 @@
+package ch.hevs.gdx2d.lib.interfaces;
+
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.PovDirection;
+import com.badlogic.gdx.math.Vector3;
+
+/**
+ * Contains the methods to interact with controllers.
+ *
+ * It allows to use multiple controllers and use the callback methods given by the libgdx controllers extension.
+ *
+ * @see com.badlogic.gdx.controllers.ControllerListener
+ * @author Christopher Métrailler (mei)
+ * @version 1.0
+ */
+public interface ControllersInterface {
+
+	// Wrapper based on `com/badlogic/gdx/controllers/ControllerListener.java` interface
+
+	/**
+	 * A {@link Controller} got connected.
+	 *
+	 * @param controller the connected controller
+	 */
+	void onControllerConnected(Controller controller);
+
+	/**
+	 * A {@link Controller} got disconnected.
+	 *
+	 * @param controller the connected controller
+	 */
+	void onControllerDisconnected(Controller controller);
+
+	/**
+	 * A button on the {@link Controller} was pressed.
+	 *
+	 * The buttonCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param buttonCode the pressed button code
+	 */
+	void onControllerKeyDown(Controller controller, int buttonCode);
+
+	/**
+	 * A button on the {@link Controller} was released.
+	 *
+	 * The buttonCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param buttonCode the released button code
+	 */
+	void onControllerKeyUp(Controller controller, int buttonCode);
+
+	/**
+	 * An axis on the {@link Controller} moved.
+	 *
+	 * The axisCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param axisCode the moved axis
+	 * @param value the axis value is in the range [-1, 1]
+	 */
+	void onControllerAxisMoved(Controller controller, int axisCode, float value);
+
+	/**
+	 * A POV (Point of View) on the {@link Controller} moved.
+	 *
+	 * The povCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param povCode the POV code
+	 * @param value the POV direction
+	 */
+	void onControllerPovMoved(Controller controller, int povCode, PovDirection value);
+
+	/**
+	 * An x-slider on the {@link Controller} moved.
+	 *
+	 * The sliderCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param sliderCode the slider code
+	 * @param value the slider value
+	 */
+	void onControllerXSliderMoved(Controller controller, int sliderCode, boolean value);
+
+	/**
+	 * An y-slider on the {@link Controller} moved.
+	 *
+	 * The sliderCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for known
+	 * controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param sliderCode the slider code
+	 * @param value the slider value
+	 */
+	void onControllerYSliderMoved(Controller controller, int sliderCode, boolean value);
+
+	/**
+	 * An accelerometer value on the {@link Controller} changed.
+	 *
+	 * The accelerometerCode is controller specific, see the <code>com.badlogic.gdx.controllers.mapping</code> package for
+	 * known controllers.
+	 *
+	 * @param controller the corresponding controller
+	 * @param accelerometerCode the accelerometer code
+	 * @param value acceleration on a 3-axis accelerometer in m/s^2
+	 */
+	void onControllerAccelerometerMoved(Controller controller, int accelerometerCode, Vector3 value);
+}

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Logger.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Logger.java
@@ -7,31 +7,44 @@ import com.badlogic.gdx.Gdx;
 /**
  * Simple logging facility using underlying {@code libgdx}.
  * <p/>
- * Be default only log error and normal messages (see #INFO).
  * Use {@link #setLogLevel(int)} to set the logger more or less verbose.
+ * <ul>
+ * <li>For snapshot versions, debug, info and error messages are displayed by
+ * default.</li>
+ * <li>For release versions, only info and error messages are displayed by
+ * default.</li>
+ * </ul>
  *
  * @author Pierre-André Mudry (mui)
  * @author Christopher Métrailler (mei)
- * @version 1.2
+ * @version 1.3
  */
 public class Logger {
 
-	/** Mute all logging. */
+	/**
+	 * Mute all logging messages.
+	 */
 	public static final int NONE = Application.LOG_NONE;
 
-	/** Logs all messages. */
+	/**
+	 * Logs all messages (default for snapshot versions).
+	 */
 	public static final int DEBUG = Application.LOG_DEBUG;
 
-	/** Log only error messages. */
-	public static final int ERROR = Application.LOG_ERROR;
-
-	/** Log error and normal messages. */
+	/**
+	 * Log error and normal messages (default for release versions).
+	 */
 	public static final int INFO = Application.LOG_INFO;
+
+	/**
+	 * Log only error messages.
+	 */
+	public static final int ERROR = Application.LOG_ERROR;
 
 	private static final String TAG = "gdx2d";
 
 	static {
-		if(Version.isSnapshot)
+		if (Version.isSnapshot)
 			Gdx.app.setLogLevel(Logger.DEBUG);
 		else
 			Gdx.app.setLogLevel(Logger.INFO);
@@ -39,6 +52,7 @@ public class Logger {
 
 	/**
 	 * Log a message.
+	 *
 	 * @param msg logging message
 	 */
 	public static void log(String msg) {
@@ -47,6 +61,7 @@ public class Logger {
 
 	/**
 	 * Log a message.
+	 *
 	 * @param tag logging tag
 	 * @param msg logging message
 	 */
@@ -55,7 +70,19 @@ public class Logger {
 	}
 
 	/**
+	 * Log a message.
+	 *
+	 * @param tag logging tag
+	 * @param format logging message format
+	 * @param args logging message args
+	 */
+	public static void log(String tag, String format, Object... args) {
+		log(tag, String.format(format, args));
+	}
+
+	/**
 	 * Log an error.
+	 *
 	 * @param msg logging message
 	 */
 	public static void error(String msg) {
@@ -64,15 +91,29 @@ public class Logger {
 
 	/**
 	 * Log an error.
+	 *
 	 * @param tag logging tag
 	 * @param msg logging message
 	 */
 	public static void error(String tag, String msg) {
-		Gdx.app.error(String.format("[%s]", tag), "error - " + msg); // Print error in red
+		Gdx.app.error(String.format("[%s]", tag), "error - " + msg); // Print error
+																																	// in red
+	}
+
+	/**
+	 * Log an error.
+	 *
+	 * @param tag logging tag
+	 * @param format logging message format
+	 * @param args logging message args
+	 */
+	public static void error(String tag, String format, Object... args) {
+		error(tag, String.format(format, args));
 	}
 
 	/**
 	 * Log a debug message.
+	 *
 	 * @param msg logging message
 	 */
 	public static void dbg(String msg) {
@@ -81,6 +122,7 @@ public class Logger {
 
 	/**
 	 * Log a debug message.
+	 *
 	 * @param tag logging tag
 	 * @param msg logging message
 	 */
@@ -89,7 +131,19 @@ public class Logger {
 	}
 
 	/**
+	 * Log a debug message.
+	 *
+	 * @param tag logging tag
+	 * @param format logging message format
+	 * @param args logging message args
+	 */
+	public static void dbg(String tag, String format, Object... args) {
+		dbg(tag, String.format(format, args));
+	}
+
+	/**
 	 * Set the logger more or less verbose.
+	 *
 	 * @param logLevel the log level
 	 */
 	public static void setLogLevel(int logLevel) {

--- a/gdx2d-library/gdx2d-desktop/gdx2d-desktop.iml
+++ b/gdx2d-library/gdx2d-desktop/gdx2d-desktop.iml
@@ -15,6 +15,7 @@
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-freetype:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-box2d:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.box2dlights:box2dlights:1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-controllers:1.5.6" level="project" />
     <orderEntry type="module" module-name="gdx2d-core" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-backend-lwjgl:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: org.lwjgl.lwjgl:lwjgl:2.9.2" level="project" />
@@ -32,5 +33,7 @@
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-platform:natives-desktop:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-box2d-platform:natives-desktop:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-freetype-platform:natives-desktop:1.5.6" level="project" />
+    <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-controllers-desktop:1.5.6" level="project" />
+    <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-controllers-platform:natives-desktop:1.5.6" level="project" />
   </component>
 </module>

--- a/gdx2d-library/gdx2d-desktop/pom.xml
+++ b/gdx2d-library/gdx2d-desktop/pom.xml
@@ -35,7 +35,6 @@
       <classifier>sources</classifier>
     </dependency>
 
-    <!-- Libgdx / Box2d desktop natives -->
     <dependency>
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-backend-lwjgl</artifactId>
@@ -47,16 +46,31 @@
       <version>${libgdx.version}</version>
       <classifier>natives-desktop</classifier>
     </dependency>
+
     <dependency>
+      <!-- Box2D extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-box2d-platform</artifactId>
       <classifier>natives-desktop</classifier>
       <version>${libgdx.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
+      <!-- Box2DLights extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-freetype-platform</artifactId>
+      <version>${libgdx.version}</version>
+      <classifier>natives-desktop</classifier>
+    </dependency>
+    <dependency>
+      <!-- Controllers extension -->
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-controllers-desktop</artifactId>
+      <version>${libgdx.version}</version>
+    </dependency>
+    <dependency>
+      <!-- Controllers extension -->
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-controllers-platform</artifactId>
       <version>${libgdx.version}</version>
       <classifier>natives-desktop</classifier>
     </dependency>

--- a/gdx2d-library/gdx2d-desktop/pom.xml
+++ b/gdx2d-library/gdx2d-desktop/pom.xml
@@ -88,6 +88,7 @@
           <dependencySourceIncludes>
             <dependencySourceInclude>ch.hevs.*</dependencySourceInclude>
           </dependencySourceIncludes>
+          <show>package</show>
         </configuration>
       </plugin>
     </plugins>

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
@@ -65,171 +65,21 @@ public class Game2D implements ApplicationListener {
 
         g = new GdxGraphics(shapeRenderer, batch, camera);
 
-        // Let's have multiple input processors
-        InputMultiplexer multiplexer = new InputMultiplexer();
-        multiplexer.addProcessor(new GestureDetector(new GestureListener() {
-
-            @Override
-            public boolean zoom(float initialDistance, float distance) {
-                app.onZoom(initialDistance, distance);
-                return false;
-            }
-
-            @Override
-            public boolean touchDown(float x, float y, int pointer, int button) {
-                return false;
-            }
-
-            @Override
-            public boolean tap(float x, float y, int count, int button) {
-                app.onTap(x, y, count, button);
-                return false;
-            }
-
-            @Override
-            public boolean pinch(Vector2 initialPointer1,
-                                 Vector2 initialPointer2, Vector2 pointer1, Vector2 pointer2) {
-                app.onPinch(initialPointer1, initialPointer2, pointer1, pointer2);
-                return false;
-            }
-
-            @Override
-            public boolean pan(float x, float y, float deltaX, float deltaY) {
-                app.onPan(x, y, deltaX, deltaY);
-                return false;
-            }
-
-            @Override
-            public boolean longPress(float x, float y) {
-                app.onLongPress(x, y);
-                return false;
-            }
-
-            @Override
-            public boolean fling(float velocityX, float velocityY, int button) {
-                app.onFling(velocityX, velocityY, button);
-                return false;
-            }
-
-            @Override
-            public boolean panStop(float v, float v1, int i, int i1) {
-                return false;
-            }
-        }));
-
-        multiplexer.addProcessor(new InputProcessor() {
-
-            @Override
-            public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-                app.onRelease(screenX, screenY, button);
-                return false;
-            }
-
-            @Override
-            public boolean touchDragged(int screenX, int screenY, int pointer) {
-                app.onDrag(screenX, Gdx.graphics.getHeight() - screenY);
-                return false;
-            }
-
-            @Override
-            public boolean touchDown(int screenX, int screenY, int pointer, int button) {
-                app.onClick(screenX, Gdx.graphics.getHeight() - screenY, button);
-                return false;
-            }
-
-            @Override
-            public boolean scrolled(int amount) {
-                app.onScroll(amount);
-                return false;
-            }
-
-            @Override
-            public boolean mouseMoved(int screenX, int screenY) {
-                return false;
-            }
-
-            @Override
-            public boolean keyUp(int keycode) {
-                app.onKeyUp(keycode);
-                return false;
-            }
-
-            @Override
-            public boolean keyTyped(char character) {
-                return false;
-            }
-
-            @Override
-            public boolean keyDown(int keycode) {
-                // Trigger about box when pressing the menu button on Android
-                if (keycode == Input.Keys.MENU) {
-                    // resolver.showAboutBox();
-                }
-                if (keycode == Input.Keys.ESCAPE) {
-                    Gdx.app.exit();
-                }
-                app.onKeyDown(keycode);
-                return false;
-            }
-        });
+        // Register multiple input processors for gestures, mouse and keyboard events
+        final InputMultiplexer multiplexer = new InputMultiplexer();
+        multiplexer.addProcessor(new GestureDetector(new GdxGestureDetector(app))); // Gestures
+        multiplexer.addProcessor(new GdxInputProcessor(app)); // Mouse and keyboard inputs
 
         Gdx.input.setInputProcessor(multiplexer);
 
+        // Register the controllers input (extension required)
         Controllers.clearListeners();
-        Controllers.addListener(new ControllerListener() {
-          @Override
-          public void connected(Controller controller) {
-            // FIXME: not called on Windows with XBox One game-pad
-          }
-
-          @Override
-          public void disconnected(Controller controller) {
-            // FIXME: not called on Windows with XBox One game-pad
-          }
-
-          @Override
-          public boolean buttonDown(Controller controller, int i) {
-            return false;
-          }
-
-          @Override
-          public boolean buttonUp(Controller controller, int i) {
-            return false;
-          }
-
-          @Override
-          public boolean axisMoved(Controller controller, int i, float v) {
-            return false;
-          }
-
-          @Override
-          public boolean povMoved(Controller controller, int i, PovDirection povDirection) {
-            return false;
-          }
-
-          @Override
-          public boolean xSliderMoved(Controller controller, int i, boolean b) {
-            // FIXME: not called on Windows with XBox One game-pad
-            return false;
-          }
-
-          @Override
-          public boolean ySliderMoved(Controller controller, int i, boolean b) {
-            // FIXME: not called on Windows with XBox One game-pad
-            return false;
-          }
-
-          @Override
-          public boolean accelerometerMoved(Controller controller, int i, Vector3 vector3) {
-            // FIXME: not called on Windows with XBox One game-pad
-            return false;
-          }
-        });
+        Controllers.addListener(new GdxControllersProcessor(app));
 
         app.onInit(); // Initialize app
 
         // FIXME: should we enumerate the controllers here and call the connect method ?
-        // app.connected();
+        // app.onControllerConnected();
     }
 
     /**

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
@@ -5,12 +5,17 @@ import ch.hevs.gdx2d.lib.Version;
 import ch.hevs.gdx2d.lib.physics.PhysicsWorld;
 import ch.hevs.gdx2d.lib.utils.Logger;
 import com.badlogic.gdx.*;
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.ControllerListener;
+import com.badlogic.gdx.controllers.Controllers;
+import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.input.GestureDetector;
 import com.badlogic.gdx.input.GestureDetector.GestureListener;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.GdxNativesLoader;
 
 /**
@@ -26,7 +31,7 @@ import com.badlogic.gdx.utils.GdxNativesLoader;
  */
 public class Game2D implements ApplicationListener {
 
-    static public GdxGraphics g;
+    public static GdxGraphics g;
 
     // Force to load native libraries (for Android Proguard)
     // FIXME Is this really required?
@@ -170,8 +175,61 @@ public class Game2D implements ApplicationListener {
 
         Gdx.input.setInputProcessor(multiplexer);
 
-        // Initialize app
-        app.onInit();
+        Controllers.clearListeners();
+        Controllers.addListener(new ControllerListener() {
+          @Override
+          public void connected(Controller controller) {
+            // FIXME: not called on Windows with XBox One game-pad
+          }
+
+          @Override
+          public void disconnected(Controller controller) {
+            // FIXME: not called on Windows with XBox One game-pad
+          }
+
+          @Override
+          public boolean buttonDown(Controller controller, int i) {
+            return false;
+          }
+
+          @Override
+          public boolean buttonUp(Controller controller, int i) {
+            return false;
+          }
+
+          @Override
+          public boolean axisMoved(Controller controller, int i, float v) {
+            return false;
+          }
+
+          @Override
+          public boolean povMoved(Controller controller, int i, PovDirection povDirection) {
+            return false;
+          }
+
+          @Override
+          public boolean xSliderMoved(Controller controller, int i, boolean b) {
+            // FIXME: not called on Windows with XBox One game-pad
+            return false;
+          }
+
+          @Override
+          public boolean ySliderMoved(Controller controller, int i, boolean b) {
+            // FIXME: not called on Windows with XBox One game-pad
+            return false;
+          }
+
+          @Override
+          public boolean accelerometerMoved(Controller controller, int i, Vector3 vector3) {
+            // FIXME: not called on Windows with XBox One game-pad
+            return false;
+          }
+        });
+
+        app.onInit(); // Initialize app
+
+        // FIXME: should we enumerate the controllers here and call the connect method ?
+        // app.connected();
     }
 
     /**

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxControllersProcessor.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxControllersProcessor.java
@@ -1,0 +1,87 @@
+package ch.hevs.gdx2d.desktop;
+
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.controllers.*;
+import com.badlogic.gdx.math.Vector3;
+
+/**
+ * Controllers input processor for gdx2d.
+ * <p/>
+ * Require the libgdx {@code controllers} extension.
+ *
+ * @see ControllerListener
+ *
+ * @author Christopher Metrailler (mei)
+ * @version 1.0
+ */
+class GdxControllersProcessor extends ControllerAdapter {
+
+	private final PortableApplication app;
+
+	/**
+	 * Controllers input processor for gdx2d.
+	 *
+	 * This processor must be registered manually to the {@link InputMultiplexer} class.
+	 *
+	 * @param app the portable application (cannot be null)
+	 * @throws IllegalArgumentException if the application is {@code null}
+	 */
+	GdxControllersProcessor(final PortableApplication app) {
+		if (app == null)
+			throw new IllegalArgumentException("PortableApplication cannot be null !");
+
+		this.app = app;
+	}
+
+	@Override
+	public void connected(Controller controller) {
+		app.onControllerConnected(controller);
+	}
+
+	@Override
+	public void disconnected(Controller controller) {
+		app.onControllerDisconnected(controller);
+	}
+
+	@Override
+	public boolean buttonDown(Controller controller, int buttonCode) {
+		app.onControllerKeyDown(controller, buttonCode);
+		return false;
+	}
+
+	@Override
+	public boolean buttonUp(Controller controller, int buttonCode) {
+		app.onControllerKeyUp(controller, buttonCode);
+		return false;
+	}
+
+	@Override
+	public boolean axisMoved(Controller controller, int axisCode, float value) {
+		app.onControllerAxisMoved(controller, axisCode, value);
+		return false;
+	}
+
+	@Override
+	public boolean povMoved(Controller controller, int povCode, PovDirection value) {
+		app.onControllerPovMoved(controller, povCode, value);
+		return false;
+	}
+
+	@Override
+	public boolean xSliderMoved(Controller controller, int sliderCode, boolean value) {
+		app.onControllerXSliderMoved(controller, sliderCode, value);
+		return false;
+	}
+
+	@Override
+	public boolean ySliderMoved(Controller controller, int sliderCode, boolean value) {
+		app.onControllerYSliderMoved(controller, sliderCode, value);
+		return false;
+	}
+
+	@Override
+	public boolean accelerometerMoved(Controller controller, int accelerometerCode, Vector3 value) {
+		app.onControllerAccelerometerMoved(controller, accelerometerCode, value);
+		return false;
+	}
+}

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxGestureDetector.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxGestureDetector.java
@@ -1,0 +1,69 @@
+package ch.hevs.gdx2d.desktop;
+
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.input.GestureDetector;
+import com.badlogic.gdx.math.Vector2;
+
+/**
+ * Input gesture processor for gdx2d.
+ *
+ * @see GestureDetector.GestureListener
+ *
+ * @author Christopher Metrailler (mei)
+ * @version 1.0
+ */
+class GdxGestureDetector extends GestureDetector.GestureAdapter {
+
+	private final PortableApplication app;
+
+	/**
+	 * Input gesture processor for gdx2d.
+	 *
+	 * This processor must be registered manually to the {@link InputMultiplexer} class.
+	 *
+	 * @param app the portable application (cannot be null)
+	 * @throws IllegalArgumentException if the application is {@code null}
+	 */
+	GdxGestureDetector(final PortableApplication app) {
+		if (app == null)
+			throw new IllegalArgumentException("PortableApplication cannot be null !");
+
+		this.app = app;
+	}
+
+	@Override
+	public boolean zoom(float initialDistance, float distance) {
+		app.onZoom(initialDistance, distance);
+		return false;
+	}
+
+	@Override
+	public boolean tap(float x, float y, int count, int button) {
+		app.onTap(x, y, count, button);
+		return false;
+	}
+
+	@Override
+	public boolean pinch(Vector2 initialPointer1, Vector2 initialPointer2, Vector2 pointer1, Vector2 pointer2) {
+		app.onPinch(initialPointer1, initialPointer2, pointer1, pointer2);
+		return false;
+	}
+
+	@Override
+	public boolean pan(float x, float y, float deltaX, float deltaY) {
+		app.onPan(x, y, deltaX, deltaY);
+		return false;
+	}
+
+	@Override
+	public boolean longPress(float x, float y) {
+		app.onLongPress(x, y);
+		return false;
+	}
+
+	@Override
+	public boolean fling(float velocityX, float velocityY, int button) {
+		app.onFling(velocityX, velocityY, button);
+		return false;
+	}
+}

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxInputProcessor.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxInputProcessor.java
@@ -1,0 +1,73 @@
+package ch.hevs.gdx2d.desktop;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.controllers.Controllers;
+
+/**
+ * Input mouse and keyboard processor for gdx2d.
+ *
+ * @see com.badlogic.gdx.InputProcessor
+ *
+ * @author Christopher Metrailler (mei)
+ * @version 1.0
+ */
+class GdxInputProcessor extends InputAdapter {
+
+	private final PortableApplication app;
+
+	/**
+	 * Input mouse and keyboard processor for gdx2d.
+	 *
+	 * This processor must be registered manually to the {@link Controllers} class.
+	 *
+	 * @param app the portable application (cannot be null)
+	 * @throws IllegalArgumentException if the application is {@code null}
+	 */
+	GdxInputProcessor(final PortableApplication app) {
+		if (app == null)
+			throw new IllegalArgumentException("PortableApplication cannot be null !");
+
+		this.app = app;
+	}
+
+	@Override
+	public boolean touchUp(int screenX, int screenY, int pointer, int button) {
+		app.onRelease(screenX, screenY, button);
+		return false;
+	}
+
+	@Override
+	public boolean touchDragged(int screenX, int screenY, int pointer) {
+		app.onDrag(screenX, Gdx.graphics.getHeight() - screenY);
+		return false;
+	}
+
+	@Override
+	public boolean touchDown(int screenX, int screenY, int pointer, int button) {
+		app.onClick(screenX, Gdx.graphics.getHeight() - screenY, button);
+		return false;
+	}
+
+	@Override
+	public boolean scrolled(int amount) {
+		app.onScroll(amount);
+		return false;
+	}
+
+	@Override
+	public boolean keyUp(int keycode) {
+		app.onKeyUp(keycode);
+		return false;
+	}
+
+	@Override
+	public boolean keyDown(int keycode) {
+		if (keycode == Input.Keys.ESCAPE) {
+			Gdx.app.exit();
+		}
+		app.onKeyDown(keycode);
+		return false;
+	}
+}

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
@@ -1,12 +1,17 @@
 package ch.hevs.gdx2d.desktop;
 
 import ch.hevs.gdx2d.lib.interfaces.*;
+import ch.hevs.gdx2d.lib.utils.Logger;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.Controllers;
+import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector2;
 
+import com.badlogic.gdx.math.Vector3;
 import java.awt.*;
 
 /**
@@ -20,14 +25,16 @@ import java.awt.*;
  * @see KeyboardInterface
  * @see GameInterface
  */
-public abstract class PortableApplication implements TouchInterface, KeyboardInterface, GameInterface, GestureInterface {
+public abstract class PortableApplication implements TouchInterface, KeyboardInterface, GameInterface,
+  GestureInterface, ControllersInterface {
+
 	// Default window dimensions
 	private static final int DEFAULT_HEIGHT = 500;
 	private static final int DEFAULT_WIDTH = 500;
 
 	@Deprecated
 	protected final boolean onAndroid = onAndroid();
-	
+
 	/**
 	 * {@code true} if the application is running on Android or {@code false} if running on desktop.
 	 */
@@ -35,7 +42,7 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 
 	/**
 	 * Detect android
-	 * 
+	 *
 	 * @return true when running on Android.
 	 */
 	public boolean onAndroid() {
@@ -46,7 +53,7 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	        return false;
 	    }
 	}
-	
+
 	/**
 	 * Creates an application using {@code gdx2d}.
 	 * Use a default windows size.
@@ -66,7 +73,7 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 		this(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 	}
 
-	
+
 	/**
 	 * Creates an application using {@code gdx2d}.
 	 * Screen dimension are ignored when running on Android.
@@ -79,7 +86,7 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	public PortableApplication(boolean onAndroid, int width, int height) {
 		this(onAndroid, width, height, false);
 	}
-	
+
 	/**
 	 * Creates an application using {@code gdx2d}.
 	 * Screen dimension are ignored when running on Android.
@@ -238,7 +245,8 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	public void onKeyUp(int keycode) {
 	}
 
-    /* GestureInterface callbacks */
+
+  /* GestureInterface callbacks */
 
 	/**
 	 * @see GameInterface#onDispose()
@@ -311,6 +319,65 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	@Override
 	public void onFling(float velocityX, float velocityY, int button) {
 	}
+
+
+  /* ControllersInterface callbacks */
+
+  @Override
+  public void connected(Controller controller) {
+    Logger.log("the controller '%s' has been connected", controller.getName());
+  }
+
+  @Override
+  public void disconnected(Controller controller) {
+    Logger.log("the controller '%s' has been disconnected", controller.getName());
+  }
+
+  private int indexOf (Controller controller) {
+    return Controllers.getControllers().indexOf(controller, true);
+  }
+
+  @Override
+  public boolean buttonDown(Controller controller, int buttonCode) {
+    Logger.log("#" + indexOf(controller) + ", button " + buttonCode + " down");
+    return false;
+  }
+
+  @Override
+  public boolean buttonUp(Controller controller, int buttonCode) {
+    Logger.log("#" + indexOf(controller) + ", button " + buttonCode + " up");
+    return false;
+  }
+
+  @Override
+  public boolean axisMoved(Controller controller, int axisIndex, float value) {
+    Logger.log("#" + indexOf(controller) + ", axis " + axisIndex + ": " + value);
+    return false;
+  }
+
+  @Override
+  public boolean povMoved(Controller controller, int povIndex, PovDirection value) {
+    Logger.log("#" + indexOf(controller) + ", pov " + povIndex + ": " + value);
+    return false;
+  }
+
+  @Override
+  public boolean xSliderMoved(Controller controller, int sliderIndex, boolean value) {
+    Logger.log("#" + indexOf(controller) + ", x slider " + sliderIndex + ": " + value);
+    return false;
+  }
+
+  @Override
+  public boolean ySliderMoved(Controller controller, int sliderIndex, boolean value) {
+    Logger.log("#" + indexOf(controller) + ", y slider " + sliderIndex + ": " + value);
+    return false;
+  }
+
+  @Override
+  public boolean accelerometerMoved(Controller controller, int accelIndex, Vector3 accel) {
+    Logger.log("#" + indexOf(controller) + ", y slider " + accelIndex + ": " + accel.x);
+    return false;
+  }
 
 	/**
 	 * Return the {@link AndroidResolver} to use Android actions.

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
@@ -1,32 +1,34 @@
 package ch.hevs.gdx2d.desktop;
 
-import ch.hevs.gdx2d.lib.interfaces.*;
-import ch.hevs.gdx2d.lib.utils.Logger;
+import java.awt.*;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
 import com.badlogic.gdx.controllers.Controller;
-import com.badlogic.gdx.controllers.Controllers;
 import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector2;
-
 import com.badlogic.gdx.math.Vector3;
-import java.awt.*;
+
+import ch.hevs.gdx2d.lib.interfaces.*;
 
 /**
- * The base class that should be sub-classed by all {@code gdx2d} applications.
- * To get the functionality required you simply have to overload the required methods.
+ * The base class that should be sub-classed by all {@code gdx2d} applications. To get the functionality required you
+ * simply have to overload the required methods.
  *
- * @author Pierre-André Mudry (mui)
- * @author Christopher Metrailler (mei)
- * @version 1.1
  * @see TouchInterface
  * @see KeyboardInterface
  * @see GameInterface
+ * @see GestureInterface
+ * @see ControllersInterface
+ *
+ * @author Pierre-André Mudry (mui)
+ * @author Christopher Metrailler (mei)
+ * @version 1.2
  */
-public abstract class PortableApplication implements TouchInterface, KeyboardInterface, GameInterface,
-  GestureInterface, ControllersInterface {
+public abstract class PortableApplication
+		implements TouchInterface, KeyboardInterface, GameInterface, GestureInterface, ControllersInterface {
 
 	// Default window dimensions
 	private static final int DEFAULT_HEIGHT = 500;
@@ -46,17 +48,16 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	 * @return true when running on Android.
 	 */
 	public boolean onAndroid() {
-	    try {
-	        Class.forName("android.app.Activity");
-	        return true;
-	    } catch(ClassNotFoundException e) {
-	        return false;
-	    }
+		try {
+			Class.forName("android.app.Activity");
+			return true;
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
 	}
 
 	/**
-	 * Creates an application using {@code gdx2d}.
-	 * Use a default windows size.
+	 * Creates an application using {@code gdx2d}. Use a default windows size.
 	 *
 	 * @param onAndroid {@code true} if running on Android, {@code false} otherwise
 	 */
@@ -66,21 +67,18 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	}
 
 	/**
-	 * Creates an application using {@code gdx2d}.
-	 * Use a default windows size.
+	 * Creates an application using {@code gdx2d}. Use a default windows size.
 	 */
 	public PortableApplication() {
 		this(DEFAULT_WIDTH, DEFAULT_HEIGHT);
 	}
 
-
 	/**
-	 * Creates an application using {@code gdx2d}.
-	 * Screen dimension are ignored when running on Android.
+	 * Creates an application using {@code gdx2d}. Screen dimension are ignored when running on Android.
 	 *
 	 * @param onAndroid {@code true} if running on Android, {@code false} otherwise
-	 * @param width     The width of the screen (only for desktop)
-	 * @param height    The height of the screen (only for desktop)
+	 * @param width The width of the screen (only for desktop)
+	 * @param height The height of the screen (only for desktop)
 	 */
 	@Deprecated
 	public PortableApplication(boolean onAndroid, int width, int height) {
@@ -88,11 +86,10 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	}
 
 	/**
-	 * Creates an application using {@code gdx2d}.
-	 * Screen dimension are ignored when running on Android.
+	 * Creates an application using {@code gdx2d}. Screen dimension are ignored when running on Android.
 	 *
-	 * @param width     The width of the screen (only for desktop)
-	 * @param height    The height of the screen (only for desktop)
+	 * @param width The width of the screen (only for desktop)
+	 * @param height The height of the screen (only for desktop)
 	 */
 	public PortableApplication(int width, int height) {
 		this(width, height, false);
@@ -101,10 +98,9 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	/**
 	 * Create a full-screen {@code gdx2d} application.
 	 *
-	 * @param width      The width of the screen
-	 * @param height     The height of the screen
-	 * @param fullScreen Indicates if the application should be launched full
-	 *                   screen on desktop, or in default resolution
+	 * @param width The width of the screen
+	 * @param height The height of the screen
+	 * @param fullScreen Indicates if the application should be launched full screen on desktop, or in default resolution
 	 */
 	public PortableApplication(int width, int height, boolean fullScreen) {
 		if (onAndroid()) {
@@ -123,12 +119,12 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	}
 
 	/**
-	 * Creates an application using {@code gdx2d}, running full screen or not on desktop.
-	 * Screen dimension are ignored when running on Android.
+	 * Creates an application using {@code gdx2d}, running full screen or not on desktop. Screen dimension are ignored
+	 * when running on Android.
 	 *
-	 * @param onAndroid  {@code true} if running on Android, {@code false} otherwise
-	 * @param width      The width of the screen (only for desktop)
-	 * @param height     The height of the screen (only for desktop)
+	 * @param onAndroid {@code true} if running on Android, {@code false} otherwise
+	 * @param width The width of the screen (only for desktop)
+	 * @param height The height of the screen (only for desktop)
 	 * @param fullScreen {@code true} to create a fullscreen application (only for desktop)
 	 */
 	@Deprecated
@@ -151,11 +147,11 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 		return false;
 	}
 
-    /* TouchInterface callbacks */
+	/* TouchInterface callbacks */
 
 	/**
-	 * Change the title of the application window (works only on desktop).
-	 * This method has no effect (ignored) when running on Android.
+	 * Change the title of the application window (works only on desktop). This method has no effect (ignored) when
+	 * running on Android.
 	 *
 	 * @param title the application title
 	 */
@@ -182,55 +178,37 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	}
 
 	/**
-	 * Schedule an exit from the application.
-	 * On android, this will cause a call to {@link #onPause()} and {@link #onDispose()} some time in the future,
-	 * it will not immediately finish your application.
+	 * Schedule an exit from the application. On android, this will cause a call to {@link #onPause()} and
+	 * {@link #onDispose()} some time in the future, it will not immediately finish your application.
 	 */
 	public void exit() {
 		Gdx.app.exit();
 	}
 
+	/* KeyboardInterface callbacks */
 
-    /* KeyboardInterface callbacks */
-
-	/**
-	 * @see TouchInterface#onClick(int, int, int)
-	 */
 	@Override
 	public void onClick(int x, int y, int button) {
 	}
 
-	/**
-	 * @see TouchInterface#onDrag(int, int)
-	 */
 	@Override
 	public void onDrag(int x, int y) {
 	}
 
-
-    /* GameInterface callbacks */
+	/* GameInterface callbacks */
 
 	// Must be implemented in every subclasses:
 	// void onInit();
 	// void onGraphicRender(GdxGraphics g);
 
-	/**
-	 * @see TouchInterface#onRelease(int, int, int)
-	 */
 	@Override
 	public void onRelease(int x, int y, int button) {
 	}
 
-	/**
-	 * @see TouchInterface#onScroll(int)
-	 */
 	@Override
 	public void onScroll(int amount) {
 	}
 
-	/**
-	 * @see KeyboardInterface#onKeyDown(int)
-	 */
 	@Override
 	public void onKeyDown(int keycode) {
 		if (keycode == Input.Keys.MENU) {
@@ -238,146 +216,100 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 		}
 	}
 
-	/**
-	 * @see KeyboardInterface#onKeyUp(int)
-	 */
 	@Override
 	public void onKeyUp(int keycode) {
 	}
 
+	/* GestureInterface callbacks */
 
-  /* GestureInterface callbacks */
-
-	/**
-	 * @see GameInterface#onDispose()
-	 */
 	@Override
 	public void onDispose() {
 	}
 
-	/**
-	 * @see GameInterface#onPause()
-	 */
 	@Override
 	public void onPause() {
 		// Android only
 	}
 
-	/**
-	 * @see GameInterface#onGameLogicUpdate()
-	 */
 	@Override
 	public void onGameLogicUpdate() {
 	}
 
-	/**
-	 * @see GameInterface#onResume()
-	 */
 	@Override
 	public void onResume() {
 		// Android only
 	}
 
-	/**
-	 * @see GestureInterface#onZoom(float, float)
-	 */
 	@Override
 	public void onZoom(float initialDistance, float distance) {
 	}
 
-	/**
-	 * @see GestureInterface#onTap(float, float, int, int)
-	 */
 	@Override
 	public void onTap(float x, float y, int count, int button) {
 	}
 
-	/**
-	 * @see GestureInterface#onPinch(Vector2, Vector2, Vector2, Vector2)
-	 */
 	@Override
 	public void onPinch(Vector2 initialPointer1, Vector2 initialPointer2, Vector2 pointer1, Vector2 pointer2) {
 	}
 
-	/**
-	 * @see GestureInterface#onPan(float, float, float, float)
-	 */
 	@Override
 	public void onPan(float x, float y, float deltaX, float deltaY) {
 	}
 
-	/**
-	 * @see GestureInterface#onLongPress(float, float)
-	 */
 	@Override
 	public void onLongPress(float x, float y) {
 	}
 
-	/**
-	 * @see GestureInterface#onFling(float, float, int)
-	 */
 	@Override
 	public void onFling(float velocityX, float velocityY, int button) {
 	}
 
+	/* ControllersInterface callbacks */
 
-  /* ControllersInterface callbacks */
+	@Override
+	public void onControllerConnected(Controller controller) {
+		// FIXME: not called on Windows with XBox One game-pad
+	}
 
-  @Override
-  public void connected(Controller controller) {
-    Logger.log("the controller '%s' has been connected", controller.getName());
-  }
+	@Override
+	public void onControllerDisconnected(Controller controller) {
 
-  @Override
-  public void disconnected(Controller controller) {
-    Logger.log("the controller '%s' has been disconnected", controller.getName());
-  }
+	}
 
-  private int indexOf (Controller controller) {
-    return Controllers.getControllers().indexOf(controller, true);
-  }
+	@Override
+	public void onControllerKeyDown(Controller controller, int buttonCode) {
 
-  @Override
-  public boolean buttonDown(Controller controller, int buttonCode) {
-    Logger.log("#" + indexOf(controller) + ", button " + buttonCode + " down");
-    return false;
-  }
+	}
 
-  @Override
-  public boolean buttonUp(Controller controller, int buttonCode) {
-    Logger.log("#" + indexOf(controller) + ", button " + buttonCode + " up");
-    return false;
-  }
+	@Override
+	public void onControllerKeyUp(Controller controller, int buttonCode) {
 
-  @Override
-  public boolean axisMoved(Controller controller, int axisIndex, float value) {
-    Logger.log("#" + indexOf(controller) + ", axis " + axisIndex + ": " + value);
-    return false;
-  }
+	}
 
-  @Override
-  public boolean povMoved(Controller controller, int povIndex, PovDirection value) {
-    Logger.log("#" + indexOf(controller) + ", pov " + povIndex + ": " + value);
-    return false;
-  }
+	@Override
+	public void onControllerAxisMoved(Controller controller, int axisCode, float value) {
 
-  @Override
-  public boolean xSliderMoved(Controller controller, int sliderIndex, boolean value) {
-    Logger.log("#" + indexOf(controller) + ", x slider " + sliderIndex + ": " + value);
-    return false;
-  }
+	}
 
-  @Override
-  public boolean ySliderMoved(Controller controller, int sliderIndex, boolean value) {
-    Logger.log("#" + indexOf(controller) + ", y slider " + sliderIndex + ": " + value);
-    return false;
-  }
+	@Override
+	public void onControllerPovMoved(Controller controller, int povCode, PovDirection value) {
 
-  @Override
-  public boolean accelerometerMoved(Controller controller, int accelIndex, Vector3 accel) {
-    Logger.log("#" + indexOf(controller) + ", y slider " + accelIndex + ": " + accel.x);
-    return false;
-  }
+	}
+
+	@Override
+	public void onControllerXSliderMoved(Controller controller, int sliderCode, boolean value) {
+		// FIXME: not called on Windows with XBox One game-pad
+	}
+
+	@Override
+	public void onControllerYSliderMoved(Controller controller, int sliderCode, boolean value) {
+		// FIXME: not called on Windows with XBox One game-pad
+	}
+
+	@Override
+	public void onControllerAccelerometerMoved(Controller controller, int accelerometerCode, Vector3 value) {
+		// FIXME: not called on Windows with XBox One game-pad
+	}
 
 	/**
 	 * Return the {@link AndroidResolver} to use Android actions.
@@ -390,9 +322,8 @@ public abstract class PortableApplication implements TouchInterface, KeyboardInt
 	}
 
 	/**
-	 * Set the {@link AndroidResolver} when the application is created on
-	 * Android. The resolver must be create in an Android Activity with its
-	 * Context
+	 * Set the {@link AndroidResolver} when the application is created on Android. The resolver must be create in an
+	 * Android Activity with its Context
 	 *
 	 * @param resolver the Android resolver
 	 * @since 1.1

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Xbox.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Xbox.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package ch.hevs.gdx2d.desktop;
+
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
+
+/**
+ * Mappings for the Xbox series of controllers. Works only on desktop so far.
+ *
+ * See
+ * <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/360_controller.svg/450px-360_controller.svg.png">
+ * this image</a> which describes each button and axes.
+ *
+ * All codes are for buttons expect the L_STICK_XXX, R_STICK_XXX, L_BUMPER and R_BUMPER codes, which are axes.
+ *
+ * @author badlogic
+ */
+public class Xbox {
+	// Buttons
+	public static final int A;
+	public static final int B;
+	public static final int X;
+	public static final int Y;
+	public static final int GUIDE;
+	public static final int L_BUMPER;
+	public static final int R_BUMPER;
+	public static final int BACK;
+	public static final int START;
+	public static final int DPAD_UP;
+	public static final int DPAD_DOWN;
+	public static final int DPAD_LEFT;
+	public static final int DPAD_RIGHT;
+
+	// Axes
+	/** left trigger, -1 if not pressed, 1 if pressed **/
+	public static final int L_TRIGGER;
+	/** right trigger, -1 if not pressed, 1 if pressed **/
+	public static final int R_TRIGGER;
+	/** left stick vertical axis, -1 if up, 1 if down **/
+	public static final int L_STICK_VERTICAL_AXIS;
+	/** left stick horizontal axis, -1 if left, 1 if right **/
+	public static final int L_STICK_HORIZONTAL_AXIS;
+	/** right stick vertical axis, -1 if up, 1 if down **/
+	public static final int R_STICK_VERTICAL_AXIS;
+	/** right stick horizontal axis, -1 if left, 1 if right **/
+	public static final int R_STICK_HORIZONTAL_AXIS;
+
+	static {
+		if (SharedLibraryLoader.isWindows) {
+			A = -1;
+			B = -1;
+			X = -1;
+			Y = -1;
+			GUIDE = -1;
+			L_BUMPER = -1;
+			R_BUMPER = -1;
+			BACK = -1;
+			START = -1;
+			DPAD_UP = -1;
+			DPAD_DOWN = -1;
+			DPAD_LEFT = -1;
+			DPAD_RIGHT = -1;
+			L_TRIGGER = -1;
+			R_TRIGGER = -1;
+			L_STICK_VERTICAL_AXIS = -1;
+			L_STICK_HORIZONTAL_AXIS = -1;
+			R_STICK_VERTICAL_AXIS = -1;
+			R_STICK_HORIZONTAL_AXIS = -1;
+		} else if (SharedLibraryLoader.isLinux) {
+			A = -1;
+			B = -1;
+			X = -1;
+			Y = -1;
+			GUIDE = -1;
+			L_BUMPER = -1;
+			R_BUMPER = -1;
+			BACK = -1;
+			START = -1;
+			DPAD_UP = -1;
+			DPAD_DOWN = -1;
+			DPAD_LEFT = -1;
+			DPAD_RIGHT = -1;
+			L_TRIGGER = -1;
+			R_TRIGGER = -1;
+			L_STICK_VERTICAL_AXIS = -1;
+			L_STICK_HORIZONTAL_AXIS = -1;
+			R_STICK_VERTICAL_AXIS = -1;
+			R_STICK_HORIZONTAL_AXIS = -1;
+		} else if (SharedLibraryLoader.isMac) {
+			A = 11;
+			B = 12;
+			X = 13;
+			Y = 14;
+			GUIDE = 10;
+			L_BUMPER = 8;
+			R_BUMPER = 9;
+			BACK = 5;
+			START = 4;
+			DPAD_UP = 0;
+			DPAD_DOWN = 1;
+			DPAD_LEFT = 2;
+			DPAD_RIGHT = 3;
+			L_TRIGGER = 0;
+			R_TRIGGER = 1;
+			L_STICK_VERTICAL_AXIS = 3;
+			L_STICK_HORIZONTAL_AXIS = 2;
+			R_STICK_VERTICAL_AXIS = 5;
+			R_STICK_HORIZONTAL_AXIS = 4;
+		} else {
+			A = -1;
+			B = -1;
+			X = -1;
+			Y = -1;
+			GUIDE = -1;
+			L_BUMPER = -1;
+			R_BUMPER = -1;
+			L_TRIGGER = -1;
+			R_TRIGGER = -1;
+			BACK = -1;
+			START = -1;
+			DPAD_UP = -1;
+			DPAD_DOWN = -1;
+			DPAD_LEFT = -1;
+			DPAD_RIGHT = -1;
+			L_STICK_VERTICAL_AXIS = -1;
+			L_STICK_HORIZONTAL_AXIS = -1;
+			R_STICK_VERTICAL_AXIS = -1;
+			R_STICK_HORIZONTAL_AXIS = -1;
+		}
+	}
+
+	/**
+	 * @return whether the {@link Controller} is an Xbox controller
+	 */
+	public static boolean isXboxController(Controller controller) {
+		return controller.getName().contains("Xbox");
+	}
+}

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Xbox.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Xbox.java
@@ -29,6 +29,8 @@ import com.badlogic.gdx.utils.SharedLibraryLoader;
  * All codes are for buttons expect the L_STICK_XXX, R_STICK_XXX, L_BUMPER and R_BUMPER codes, which are axes.
  *
  * @author badlogic
+ * @author Christopher Metrailler (mei)
+ * @version 1.1
  */
 public class Xbox {
 	// Buttons
@@ -62,19 +64,21 @@ public class Xbox {
 
 	static {
 		if (SharedLibraryLoader.isWindows) {
-			A = -1;
-			B = -1;
-			X = -1;
-			Y = -1;
-			GUIDE = -1;
-			L_BUMPER = -1;
-			R_BUMPER = -1;
-			BACK = -1;
-			START = -1;
-			DPAD_UP = -1;
+			A = 0;
+			B = 1;
+			X = 2;
+			Y = 3;
+			GUIDE = -1; // Does not work
+			L_BUMPER = 4;
+			R_BUMPER = 5;
+			BACK = 6;
+			START = 7;
+
+			DPAD_UP = -1; // Use directions instead
 			DPAD_DOWN = -1;
 			DPAD_LEFT = -1;
 			DPAD_RIGHT = -1;
+
 			L_TRIGGER = -1;
 			R_TRIGGER = -1;
 			L_STICK_VERTICAL_AXIS = -1;
@@ -148,6 +152,6 @@ public class Xbox {
 	 * @return whether the {@link Controller} is an Xbox controller
 	 */
 	public static boolean isXboxController(Controller controller) {
-		return controller.getName().contains("Xbox");
+		return controller.getName().toLowerCase().contains("xbox");
 	}
 }

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/package-info.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Desktop backend for the {@code gdx2d} library.
+ * <p/>
+ * The desktop backend is available in the {@code gdx2d-desktop} Maven artifact. It depends on the {@code gdx2d-core}
+ * library implementation.
+ *
+ * @author Christopher Metrailler (mei)
+ * @version 1.0
+ */
+package ch.hevs.gdx2d.desktop;

--- a/gdx2d-library/gdx2d-lib.iml
+++ b/gdx2d-library/gdx2d-lib.iml
@@ -12,5 +12,6 @@
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-freetype:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-box2d:1.5.6" level="project" />
     <orderEntry type="library" name="Maven: com.badlogicgames.box2dlights:box2dlights:1.3" level="project" />
+    <orderEntry type="library" name="Maven: com.badlogicgames.gdx:gdx-controllers:1.5.6" level="project" />
   </component>
 </module>

--- a/gdx2d-library/pom.xml
+++ b/gdx2d-library/pom.xml
@@ -27,27 +27,36 @@
     <module>gdx2d-desktop</module>
   </modules>
 
-  <!-- Shared dependencies used in every gdx2d modules -->
   <dependencies>
     <dependency>
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx</artifactId>
       <version>${libgdx.version}</version>
     </dependency>
+
     <dependency>
+      <!-- FreeTypeFont extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-freetype</artifactId>
       <version>${libgdx.version}</version>
     </dependency>
     <dependency>
+      <!-- Box2D extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-box2d</artifactId>
       <version>${libgdx.version}</version>
     </dependency>
     <dependency>
+      <!-- Box2DLights extension -->
       <groupId>com.badlogicgames.box2dlights</groupId>
       <artifactId>box2dlights</artifactId>
       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <!-- Controllers extension -->
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-controllers</artifactId>
+      <version>${libgdx.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This PR contains a basic interface to work with the `controllers` extensions of libgdx (related to #131).
A basic demo can be used to check if the controller is detected or not, and print some information when buttons are pressed and sliders are moved. In order to use the`DemoControllers`, you have to compile the `core` and `desktop` projects.

Current implementation state:
 1. I have only tested the demo with the XBox One controller.
 2. The callbacks `` and `` are not called. We must poll the state of the controllers to known when it is connected or not.
 3. The buttons and sliders codes of the XBox controller are not the same on each OS. I changes some codes for Windows, but not for all platforms yet.

By merging this in the `develop` branch, we will have a snapshot version ready for the students interested in using a controller.