### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/components/colors/PaletteGenerator.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/components/colors/PaletteGenerator.java
@@ -20,6 +20,9 @@ public class PaletteGenerator {
 
 	private static Random random = new Random(123);
 
+	private PaletteGenerator() {
+	}
+
 	public static Color RandomMix(Color color1, Color color2, Color color3, float greyControl) {
 		int randomIndex = random.nextInt(255) % 3;
 

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Logger.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Logger.java
@@ -37,6 +37,9 @@ public class Logger {
 			Gdx.app.setLogLevel(Logger.INFO);
 	}
 
+	private Logger() {
+	}
+
 	/**
 	 * Log a message.
 	 * @param msg logging message

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Utils.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/Utils.java
@@ -10,6 +10,9 @@ import com.badlogic.gdx.Gdx;
  */
 public class Utils {
 
+	private Utils() {
+	}
+
 	/**
 	 * Checks that gdx is correctly loaded.
 	 * <p/>

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/catmull/CatmullRomUtils.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/utils/catmull/CatmullRomUtils.java
@@ -7,6 +7,9 @@ import com.badlogic.gdx.math.Vector2;
  * Adapted from http://hawkesy.blogspot.ch/2010/05/catmull-rom-spline-curve-implementation.html
  */
 public class CatmullRomUtils {
+	private CatmullRomUtils() {
+	}
+
 	/**
 	 * Creates catmull spline curves between the points array.
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Ayman Abdelghany.