### PR TITLE
[squid:S1197] Array designators "[]" should be on the type, not the variable

### DIFF
--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/accelerometer/DemoAccelerometer.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/accelerometer/DemoAccelerometer.java
@@ -19,7 +19,7 @@ public class DemoAccelerometer extends PortableApplication {
 	// For low-pass filtering
 	private float smoothedValue = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoAccelerometer();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/gestures/DemoGesture.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/gestures/DemoGesture.java
@@ -26,7 +26,7 @@ public class DemoGesture extends PortableApplication {
 		}
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoGesture();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/perf_tests/Benchmarker.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/perf_tests/Benchmarker.java
@@ -21,7 +21,7 @@ public class Benchmarker extends PortableApplication {
   private class FastRandom
   {
     private Random r;
-    private float cache[];
+    private float[] cache;
     private int i;
     FastRandom(long seed, int cache_size)
     {
@@ -53,7 +53,7 @@ public class Benchmarker extends PortableApplication {
     abstract void draw(GdxGraphics g, long n);
   }
 
-  private Tester testers[] = {
+  private Tester[] testers = {
     new Tester("setPixel") {
       @Override
       void draw(GdxGraphics g, long n) {
@@ -197,7 +197,7 @@ public class Benchmarker extends PortableApplication {
     }
   };
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     new Benchmarker();
   }
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/perf_tests/GdxGraphicsTest.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/perf_tests/GdxGraphicsTest.java
@@ -12,7 +12,7 @@ import com.badlogic.gdx.graphics.Color;
  */
 public class GdxGraphicsTest extends PortableApplication {
 
-  public static void main(String args[]) {
+  public static void main(String[] args) {
     new GdxGraphicsTest();
   }
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/DemoPolygonPhysics.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/DemoPolygonPhysics.java
@@ -29,14 +29,14 @@ public class DemoPolygonPhysics extends PortableApplication {
 	@Override
 	public void onInit() {
 		// A triangle
-		Vector2 obj1[] = {
+		Vector2[] obj1 = {
 				new Vector2(100, 100),
 				new Vector2(200, 100),
 				new Vector2(150, 200)
 		};
 
 		// A special polygon
-		Vector2 obj2[] = {
+		Vector2[] obj2 = {
 				new Vector2(0, 0),
 				new Vector2(4, 0),
 				new Vector2(5, 3),

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/chains/DemoChainPhysics.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/chains/DemoChainPhysics.java
@@ -49,7 +49,7 @@ public class DemoChainPhysics extends PortableApplication {
 		super(w, h);
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoChainPhysics(1000, 600);
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/collisions/DemoCollisionListener.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/collisions/DemoCollisionListener.java
@@ -26,7 +26,7 @@ public class DemoCollisionListener extends PortableApplication {
 	boolean generate = false;
 	BumpyBall b1, b2, b3, b4;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoCollisionListener();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/collisions/DemoSlowCollisions.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/collisions/DemoSlowCollisions.java
@@ -22,7 +22,7 @@ public class DemoSlowCollisions extends PortableApplication {
 
 	BumpyBall b1, b2;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoSlowCollisions();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/gears/DemoRotateGears.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/gears/DemoRotateGears.java
@@ -50,7 +50,7 @@ public class DemoRotateGears extends PortableApplication {
 		float minute;
 
 		TimeFloat() {
-			String t[] = new SimpleDateFormat("HH:mm:ss").format(new Date())
+			String[] t = new SimpleDateFormat("HH:mm:ss").format(new Date())
 					.split(":");
 			hour = Float.parseFloat(t[0]);
 			minute = Float.parseFloat(t[1]);
@@ -101,7 +101,7 @@ public class DemoRotateGears extends PortableApplication {
 		super(512, 256);
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoRotateGears();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoMixer.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoMixer.java
@@ -73,7 +73,7 @@ public class DemoMixer extends PortableApplication {
 	float width, height;
 	Rotor rotor;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoMixer();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoRopeJoint.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoRopeJoint.java
@@ -27,7 +27,7 @@ public class DemoRopeJoint extends PortableApplication {
 	// Contains all the objects that will be simulated
 	DebugRenderer debugRenderer;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoRopeJoint();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoWindmill.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/joints/DemoWindmill.java
@@ -46,7 +46,7 @@ public class DemoWindmill extends PortableApplication {
 	int GENERATION_RATE = 2;
 	boolean generate = false;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoWindmill();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/motors/DemoRotateMotor.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/motors/DemoRotateMotor.java
@@ -51,7 +51,7 @@ public class DemoRotateMotor extends PortableApplication {
 		super(512, 256);
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoRotateMotor();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/particle/DemoParticlePhysics.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/physics/particle/DemoParticlePhysics.java
@@ -39,7 +39,7 @@ public class DemoParticlePhysics extends PortableApplication {
 		super(x, y);
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoParticlePhysics(1000, 600);
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/selector/SelectedDemos.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/selector/SelectedDemos.java
@@ -15,16 +15,16 @@ class SelectedDemos {
 
 	static class DemoCategory {
 		public String name;
-		DemoDescriptor descs[];
+		DemoDescriptor[] descs;
 
-		DemoCategory(String n, DemoDescriptor d[])
+		DemoCategory(String n, DemoDescriptor[] d)
 		{
 			name = n;
 			descs = d;
 		}
 	}
 
-	static DemoCategory list[] =
+	static DemoCategory[] list =
 	{
 		new DemoCategory
 		(

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/DemoAllShaders.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/DemoAllShaders.java
@@ -26,7 +26,7 @@ public class DemoAllShaders extends PortableApplication {
 	private int previousShaderID = currentShaderID;
 	private Vector2 mouse = new Vector2();
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoAllShaders();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoConvolution.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoConvolution.java
@@ -16,7 +16,7 @@ public class DemoConvolution extends PortableApplication {
 
 	int currentMatrix = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoConvolution();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoJulia.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoJulia.java
@@ -21,7 +21,7 @@ public class DemoJulia extends PortableApplication {
 	float scale = 1.10f;
 	Vector2 offset = new Vector2(0, 0);
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoJulia();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoMultipleTextures.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoMultipleTextures.java
@@ -15,7 +15,7 @@ public class DemoMultipleTextures extends PortableApplication {
 	float time = 0;
 	int i = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoMultipleTextures();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoPostProcessing.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoPostProcessing.java
@@ -66,7 +66,7 @@ public class DemoPostProcessing extends PortableApplication {
 		shaderEnabled = !shaderEnabled;
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoPostProcessing();
 	}
 }

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoShaderPartialTextureRendering.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoShaderPartialTextureRendering.java
@@ -13,7 +13,7 @@ public class DemoShaderPartialTextureRendering extends PortableApplication {
 
 	double t = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderPartialTextureRendering();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoTexture.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/DemoTexture.java
@@ -17,7 +17,7 @@ public class DemoTexture extends PortableApplication {
 	boolean clicked = false;
 	boolean image1 = true;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoTexture();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/inprogress/DemoBackbuffer.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/advanced/inprogress/DemoBackbuffer.java
@@ -22,7 +22,7 @@ public class DemoBackbuffer extends PortableApplication {
 	FrameBuffer fbo;
 	Texture t;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoBackbuffer();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderCircleAntiAlias.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderCircleAntiAlias.java
@@ -23,7 +23,7 @@ public class DemoShaderCircleAntiAlias extends PortableApplication {
 	private float time = 0;
 	private float radius = 100;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderCircleAntiAlias();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse1.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse1.java
@@ -35,7 +35,7 @@ public class DemoShaderMouse1 extends PortableApplication {
 		g.drawSchoolLogo();
 	}
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderMouse1();
 	}
 }

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse2.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse2.java
@@ -14,7 +14,7 @@ public class DemoShaderMouse2 extends PortableApplication {
 
 	Circle c;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderMouse2();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse3.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/circles/DemoShaderMouse3.java
@@ -17,7 +17,7 @@ public class DemoShaderMouse3 extends PortableApplication {
 	Circle c;
 	float time = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderMouse3();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderGradient.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderGradient.java
@@ -11,7 +11,7 @@ import ch.hevs.gdx2d.lib.GdxGraphics;
  */
 public class DemoShaderGradient extends PortableApplication {
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderGradient();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderParticles.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderParticles.java
@@ -16,7 +16,7 @@ public class DemoShaderParticles extends PortableApplication {
 
 	private float time = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderParticles();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderSimple.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/shaders/simple/DemoShaderSimple.java
@@ -13,7 +13,7 @@ public class DemoShaderSimple extends PortableApplication {
 
 	private float time = 0;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoShaderSimple();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoJuliaFractal.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoJuliaFractal.java
@@ -68,7 +68,7 @@ public class DemoJuliaFractal extends PortableApplication {
 	}
 
 	// Java main for the desktop demonstration
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoJuliaFractal();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoSimpleShapes.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/simple/DemoSimpleShapes.java
@@ -15,7 +15,7 @@ import com.badlogic.gdx.math.Vector2;
  */
 public class DemoSimpleShapes extends PortableApplication {
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoSimpleShapes();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/spritesheet/DemoSpriteSheet.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/spritesheet/DemoSpriteSheet.java
@@ -37,7 +37,7 @@ public class DemoSpriteSheet extends PortableApplication {
 	int currentFrame = 0;
 	int nFrames = 4;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoSpriteSheet();
 	}
 

--- a/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/tween/interpolatorengine/DemoPositionInterpolator.java
+++ b/gdx2d-demoDesktop/src/ch/hevs/gdx2d/demos/tween/interpolatorengine/DemoPositionInterpolator.java
@@ -23,7 +23,7 @@ public class DemoPositionInterpolator extends PortableApplication {
 	private Ball[] balls;
 	private int height, width, margin;
 
-	public static void main(String args[]) {
+	public static void main(String[] args) {
 		new DemoPositionInterpolator();
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - “Array designators "[]" should be on the type, not the variable”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.
Ayman Abdelghany.