### PR TITLE
Version upgrade for LibGDX and LWJGL so that it works on ARM64 macs.

### DIFF
--- a/gdx2d-demoDesktop/pom.xml
+++ b/gdx2d-demoDesktop/pom.xml
@@ -44,6 +44,28 @@
       <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-backend-lwjgl3</artifactId>
+      <version>${libgdx.version}</version>
+    </dependency>
+
+    <!-- For Swing integration with LWJGL2 -->
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-backend-lwjgl</artifactId>
+      <version>${libgdx.version}</version>
+    </dependency>
+
+    <!-- For LWJGL2 natives required for Swing integration -->
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-platform</artifactId>
+      <version>${libgdx.version}</version>
+      <classifier>natives-desktop</classifier>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/gdx2d-demoDesktop/src/main/kotlin/ch/hevs/gdx2d/demos/controllers/DemoControllers.kt
+++ b/gdx2d-demoDesktop/src/main/kotlin/ch/hevs/gdx2d/demos/controllers/DemoControllers.kt
@@ -3,7 +3,6 @@ package ch.hevs.gdx2d.demos.controllers
 import ch.hevs.gdx2d.components.bitmaps.BitmapImage
 import com.badlogic.gdx.controllers.Controller
 import com.badlogic.gdx.controllers.Controllers
-import com.badlogic.gdx.controllers.PovDirection
 
 import ch.hevs.gdx2d.desktop.PortableApplication
 import ch.hevs.gdx2d.desktop.Xbox
@@ -135,8 +134,8 @@ class DemoControllers : PortableApplication(700, 700, false) {
             rightSickVal.y = value
     }
 
-    override fun onControllerPovMoved(controller: Controller, povCode: Int, value: PovDirection) {
-        Logger.log(TAG, "POV: $value")
+    override fun onControllerPovMoved(controller: Controller, povCode: Int, value: Int) {
+        Logger.log(TAG, "POV direction value: $value")
     }
 }
 

--- a/gdx2d-demoDesktop/src/main/kotlin/ch/hevs/gdx2d/demos/tilemap/advanced/DemoTileAdvanced.kt
+++ b/gdx2d-demoDesktop/src/main/kotlin/ch/hevs/gdx2d/demos/tilemap/advanced/DemoTileAdvanced.kt
@@ -58,7 +58,7 @@ class DemoTileAdvanced : PortableApplication() {
 
         // Camera follows the hero
         g.zoom(zoom)
-        g.moveCamera(hero.position.x, hero.position.y, tiledLayer.width * tiledLayer.tileWidth, tiledLayer.height * tiledLayer.tileHeight)
+        g.moveCamera(hero.position.x.toFloat(), hero.position.y.toFloat(), (tiledLayer.width * tiledLayer.tileWidth).toFloat(), (tiledLayer.height * tiledLayer.tileHeight).toFloat())
 
         // Render the tilemap
         tiledMapRenderer.setView(g.camera)

--- a/gdx2d-helloDesktop/pom.xml
+++ b/gdx2d-helloDesktop/pom.xml
@@ -38,6 +38,19 @@
       <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-backend-lwjgl3</artifactId>
+      <version>${libgdx.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.badlogicgames.gdx</groupId>
+      <artifactId>gdx-platform</artifactId>
+      <version>${libgdx.version}</version>
+      <classifier>natives-desktop</classifier>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gdx2d-library/README.md
+++ b/gdx2d-library/README.md
@@ -65,10 +65,11 @@ The `gdx2d-core` dependencies are:
 
 The `gdx2d-desktop` dependencies are:
 
- * `com.badlogicgames.gdx:gdx-backend-lwjgl:${libgdx.version}`
+ * `com.badlogicgames.gdx:gdx-backend-lwjgl3:${libgdx.version}`
  * `com.badlogicgames.gdx:gdx-platform:${libgdx.version}`
  * `com.badlogicgames.gdx:gdx-box2d-platform:${libgdx.version}`
  * `com.badlogicgames.gdx:gdx-freetype-platform:${libgdx.version}`
+ * `com.badlogicgames.gdx:gdx-backend-lwjgl:${libgdx.version}` (for Swing integration)
 
 ## Library resources
 

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
@@ -926,6 +926,16 @@ public class GdxGraphics implements Disposable {
 	}
 
 	/**
+	 * Set a new camera for rendering.
+	 *
+	 * @param camera the new camera to use
+	 */
+	public void setCamera(OrthographicCamera camera) {
+		this.camera = camera;
+		cameraUpdated();
+	}
+
+	/**
 	 * Draw the current assigned shader.
 	 */
 	public void drawShader() {

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/Version.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/Version.java
@@ -6,12 +6,12 @@ package ch.hevs.gdx2d.lib;
 public class Version {
 
   /** Copyright and authors information. */
-  public final static String COPY = "mui, chn, mei, pim (c) 2012-2016";
+  public final static String COPY = "mui, chn, mei, pim (c) 2012-2025";
 
   /**
    * Current version name of the gdx2d library (major.minor.revision).
    */
-  public final static String VERSION = "1.2.2";
+  public final static String VERSION = "1.2.3";
 
   /**
    * Indicates if it is a debug or release version.

--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/interfaces/ControllersInterface.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/interfaces/ControllersInterface.java
@@ -1,7 +1,6 @@
 package ch.hevs.gdx2d.lib.interfaces;
 
 import com.badlogic.gdx.controllers.Controller;
-import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector3;
 
 /**
@@ -73,9 +72,9 @@ public interface ControllersInterface {
 	 *
 	 * @param controller the corresponding controller
 	 * @param povCode the POV code
-	 * @param value the POV direction
+	 * @param value the POV direction as an integer (removed PovDirection enum for compatibility)
 	 */
-	void onControllerPovMoved(Controller controller, int povCode, PovDirection value);
+	void onControllerPovMoved(Controller controller, int povCode, int value);
 
 	/**
 	 * An x-slider on the {@link Controller} moved.

--- a/gdx2d-library/gdx2d-desktop/pom.xml
+++ b/gdx2d-library/gdx2d-desktop/pom.xml
@@ -37,9 +37,11 @@
 
     <dependency>
       <groupId>com.badlogicgames.gdx</groupId>
-      <artifactId>gdx-backend-lwjgl</artifactId>
+      <artifactId>gdx-backend-lwjgl3</artifactId>
       <version>${libgdx.version}</version>
     </dependency>
+
+    <!-- Default desktop natives -->
     <dependency>
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-platform</artifactId>
@@ -47,33 +49,31 @@
       <classifier>natives-desktop</classifier>
     </dependency>
 
+
+    <!-- Box2D extension -->
     <dependency>
-      <!-- Box2D extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-box2d-platform</artifactId>
       <classifier>natives-desktop</classifier>
       <version>${libgdx.version}</version>
     </dependency>
+
+
+    <!-- Box2DLights extension -->
     <dependency>
-      <!-- Box2DLights extension -->
       <groupId>com.badlogicgames.gdx</groupId>
       <artifactId>gdx-freetype-platform</artifactId>
       <version>${libgdx.version}</version>
       <classifier>natives-desktop</classifier>
     </dependency>
+
     <dependency>
       <!-- Controllers extension -->
-      <groupId>com.badlogicgames.gdx</groupId>
+      <groupId>com.badlogicgames.gdx-controllers</groupId>
       <artifactId>gdx-controllers-desktop</artifactId>
-      <version>${libgdx.version}</version>
+      <version>2.2.2</version>
     </dependency>
-    <dependency>
-      <!-- Controllers extension -->
-      <groupId>com.badlogicgames.gdx</groupId>
-      <artifactId>gdx-controllers-platform</artifactId>
-      <version>${libgdx.version}</version>
-      <classifier>natives-desktop</classifier>
-    </dependency>
+
   </dependencies>
 
   <build>

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/Game2D.java
@@ -8,7 +8,6 @@ import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.input.GestureDetector;
-import com.badlogic.gdx.utils.GdxNativesLoader;
 
 import ch.hevs.gdx2d.lib.GdxGraphics;
 import ch.hevs.gdx2d.lib.Version;
@@ -31,12 +30,6 @@ import javax.swing.JFrame;
 public class Game2D implements ApplicationListener {
 
 	public static GdxGraphics g;
-
-	// Force to load native libraries (for Android Proguard)
-	// FIXME Is this really required?
-	static {
-		GdxNativesLoader.load();
-	}
 
 	public OrthographicCamera camera;
 	protected PortableApplication app;
@@ -96,6 +89,10 @@ public class Game2D implements ApplicationListener {
 	 * Called when the screen has been resized.
 	 */
 	public void resize(int width, int height) {
+		// Update camera when window is resized
+		camera.setToOrtho(false, width, height);
+		camera.update();
+		//g.setCamera(camera);
 	}
 
 	/**

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxConfig.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxConfig.java
@@ -1,42 +1,70 @@
 package ch.hevs.gdx2d.desktop;
 
 import com.badlogic.gdx.Files;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.graphics.Color;
 
 /**
  * Default configuration for {@code gdx2d} applications running on desktop.
  *
  * @author Pierre-André Mudry (mui)
+ * @version 1.1
  */
 public class GdxConfig {
 
-	// FIXME: only used for desktop applications, must not be included in the library project
+    /**
+     * Get LWJGL configuration with default settings (500x500 window)
+     *
+     * @return LWJGL application configuration
+     */
+    public static Lwjgl3ApplicationConfiguration getLwjglConfig() {
+        return getLwjglConfig(500, 500, false);
+    }
 
-	static public LwjglApplicationConfiguration getLwjglConfig(int width, int height, boolean fullScreen) {
-		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		config.resizable = false;
-		config.useGL30 = false;
-		config.height = height;
-		config.width = width;
-		config.fullscreen = fullScreen;
-		config.title = "Gdx2d desktop application";
-		config.vSyncEnabled = true; // Ignored under Linux
-		config.foregroundFPS = 60; // Target value if vSync not working
-		config.backgroundFPS = config.foregroundFPS;
-		config.samples = 3; // Multi-sampling enables anti-alias for lines
-		config.forceExit = false; // Setting true calls system.exit(), with no coming back
+    /**
+     * Get LWJGL configuration
+     * <p/>
+     * Default resolution available for the windowed mode:
+     * <ul>
+     * <li>640 * 480 (4:3)
+     * <li>800 * 600 (4:3)
+     * <li>1024 * 768 (4:3)
+     * <li>1280 * 720 (16:9)
+     * <li>1366 * 768 (16:9)
+     * <li>1600 * 900 (16:9)
+     * <li>1920 * 1080 (16:9)
+     * </ul>
+     *
+     * @param width      Window width
+     * @param height     Window height
+     * @param fullScreen Create a fullscreen window
+     * @return The configuration for LWJGL
+     */
+    public static Lwjgl3ApplicationConfiguration getLwjglConfig(int width, int height, boolean fullScreen) {
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setResizable(false);
+        config.useVsync(true);
+        config.setTitle("Gdx2d desktop application");
 
-		final String os = System.getProperty("os.name").toLowerCase();
+        // Set window size
+        config.setWindowedMode(width, height);
 
-		// Under windows, the icon *must* be the small one
-		if (os.contains("win")) {
-			config.addIcon("res/lib/icon16.png", Files.FileType.Internal);
-		}
+        if (fullScreen) {
+            config.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
+        }
 
-		config.addIcon("res/lib/icon32.png", Files.FileType.Internal);
-		config.addIcon("res/lib/icon64.png", Files.FileType.Internal);
+        // Set up initial background color to black
+        config.setInitialBackgroundColor(Color.BLACK);
 
-		return config;
-	}
+        // 4 samples for multi-sampling enables anti-alias for lines
+        config.setBackBufferConfig(8, 8, 8, 8, 16, 0, 4);
 
+        // Use OpenGL 2.0 for compatibility (major=2, minor=0)
+        config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL20, 2, 0);
+
+        // Set window icons
+        config.setWindowIcon("res/lib/icon16.png", "res/lib/icon32.png", "res/lib/icon64.png");
+
+        return config;
+    }
 }

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxControllersProcessor.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxControllersProcessor.java
@@ -61,25 +61,29 @@ class GdxControllersProcessor extends ControllerAdapter {
 		return false;
 	}
 
-	@Override
-	public boolean povMoved(Controller controller, int povCode, PovDirection value) {
+	// PovDirection was removed in gdx-controllers 2.x, replaced with direct button handling
+	// This method no longer exists in the API
+	public boolean povMoved(Controller controller, int povCode, int value) {
 		app.onControllerPovMoved(controller, povCode, value);
 		return false;
 	}
 
-	@Override
+	// Methods below no longer exist in the gdx-controllers 2.x API
+	// Kept for compatibility with old code but no longer called
+
+	// No longer in the API
 	public boolean xSliderMoved(Controller controller, int sliderCode, boolean value) {
 		app.onControllerXSliderMoved(controller, sliderCode, value);
 		return false;
 	}
 
-	@Override
+	// No longer in the API
 	public boolean ySliderMoved(Controller controller, int sliderCode, boolean value) {
 		app.onControllerYSliderMoved(controller, sliderCode, value);
 		return false;
 	}
 
-	@Override
+	// No longer in the API
 	public boolean accelerometerMoved(Controller controller, int accelerometerCode, Vector3 value) {
 		app.onControllerAccelerometerMoved(controller, accelerometerCode, value);
 		return false;

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxInputProcessor.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/GdxInputProcessor.java
@@ -51,8 +51,8 @@ class GdxInputProcessor extends InputAdapter {
 	}
 
 	@Override
-	public boolean scrolled(int amount) {
-		app.onScroll(amount);
+	public boolean scrolled(float amountX, float amountY) {
+		app.onScroll((int)amountY);  // Convert to int for backwards compatibility
 		return false;
 	}
 

--- a/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
+++ b/gdx2d-library/gdx2d-desktop/src/main/java/ch/hevs/gdx2d/desktop/PortableApplication.java
@@ -4,14 +4,15 @@ import java.awt.*;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
-import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.controllers.Controller;
-import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 
 import ch.hevs.gdx2d.lib.interfaces.*;
+
+import javax.swing.SwingUtilities;
 
 /**
  * The base class that should be sub-classed by all {@code gdx2d} applications. To get the functionality required you
@@ -113,9 +114,24 @@ public abstract class PortableApplication
 			height = gd.getDisplayMode().getHeight();
 		}
 
-		// We only create a context when we were not built from the DemoSelector
-		if (!onAndroid() && !fromDemoSelector() && CreateLwjglApplication)
-			createLwjglApplication(width, height, fullScreen);
+		// Store parameters for deferred creation
+		this.deferredWidth = width;
+		this.deferredHeight = height;
+		this.deferredFullScreen = fullScreen;
+		
+		// Schedule creation for after constructor completes
+		if (!onAndroid() && !fromDemoSelector() && CreateLwjglApplication) {
+			// Check if we're on macOS - GLFW requires main thread
+			String osName = System.getProperty("os.name").toLowerCase();
+			if (osName.contains("mac")) {
+				// On macOS: Set flag and let run() method handle creation
+				pendingCreation = true;
+				// Call .run() from main method after object construction
+			} else {
+				// On other platforms: Use EDT which works fine
+				SwingUtilities.invokeLater(() -> createLwjglApplication(deferredWidth, deferredHeight, deferredFullScreen));
+			}
+		}
 	}
 
 	/**
@@ -129,8 +145,15 @@ public abstract class PortableApplication
 	 */
 	@Deprecated
 	public PortableApplication(boolean onAndroid, int width, int height, boolean fullScreen) {
-		if (!onAndroid && !fromDemoSelector() && CreateLwjglApplication)
-			createLwjglApplication(width, height, fullScreen);
+		// DEFER LibGDX application creation until after construction completes
+		this.deferredWidth = width;
+		this.deferredHeight = height;
+		this.deferredFullScreen = fullScreen;
+		
+		// Schedule creation for after constructor completes
+		if (!onAndroid && !fromDemoSelector() && CreateLwjglApplication) {
+			SwingUtilities.invokeLater(() -> createLwjglApplication(deferredWidth, deferredHeight, deferredFullScreen));
+		}
 	}
 
 	private boolean fromDemoSelector() {
@@ -297,8 +320,8 @@ public abstract class PortableApplication
 	}
 
 	@Override
-	public void onControllerPovMoved(Controller controller, int povCode, PovDirection value) {
-
+	public void onControllerPovMoved(Controller controller, int povCode, int value) {
+		// Updated to use int instead of PovDirection for compatibility with gdx-controllers 2.x
 	}
 
 	@Override
@@ -340,13 +363,33 @@ public abstract class PortableApplication
 	// TODO This is ugly and only required for the DemoSwingIntegration to prevent the creation of context
 	public static boolean CreateLwjglApplication = true;
 
+	// Fields to store deferred creation parameters
+	private int deferredWidth;
+	private int deferredHeight;
+	private boolean deferredFullScreen;
+	private boolean pendingCreation = false;
+
+	/**
+	 * Start the application. Call this after construction to complete LibGDX initialization.
+	 * This handles platform-specific threading requirements automatically.
+	 * 
+	 * Usage: new MyGame().run()
+	 */
+	public void run() {
+		if (pendingCreation) {
+			createLwjglApplication(deferredWidth, deferredHeight, deferredFullScreen);
+			pendingCreation = false;
+		}
+		// On non-macOS platforms, SwingUtilities.invokeLater already handled creation
+	}
+
+
 	private void createLwjglApplication(int width, int height, boolean fullScreen) {
 		assert (!onAndroid());
 		Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
 
-		LwjglApplicationConfiguration config = GdxConfig.getLwjglConfig(width, height, fullScreen);
-
+		Lwjgl3ApplicationConfiguration config = GdxConfig.getLwjglConfig(width, height, fullScreen);
 		Game2D theGame = new Game2D(this);
-		new LwjglApplication(theGame, config);
+		new Lwjgl3Application(theGame, config);
 	}
 }

--- a/gdx2d-library/pom.xml
+++ b/gdx2d-library/pom.xml
@@ -13,11 +13,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
-    <libgdx.version>1.9.8</libgdx.version>
-    <gdx2d.version>1.2.2</gdx2d.version>
+    <libgdx.version>1.12.0</libgdx.version>
+    <gdx2d.version>1.2.3</gdx2d.version>
     <gdx2d.url>https://hevs-isi.github.io/gdx2d/</gdx2d.url>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <artifactId>gdx2d-lib</artifactId>
@@ -61,9 +61,9 @@
     </dependency>
     <dependency>
       <!-- Controllers extension -->
-      <groupId>com.badlogicgames.gdx</groupId>
-      <artifactId>gdx-controllers</artifactId>
-      <version>${libgdx.version}</version>
+      <groupId>com.badlogicgames.gdx-controllers</groupId>
+      <artifactId>gdx-controllers-core</artifactId>
+      <version>2.2.2</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,10 +21,11 @@
   </organization>
 
   <properties>
-    <gdx2d.version>1.2.2</gdx2d.version>
+    <gdx2d.version>1.2.3</gdx2d.version>
+    <libgdx.version>1.12.0</libgdx.version>
     <kotlin.version>1.3.31</kotlin.version>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <issueManagement>
@@ -194,8 +195,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/student.sh
+++ b/student.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Exit on error
+set -e
+
 mvn clean 
 
 #Package library
@@ -15,5 +18,7 @@ cp -r gdx2d-demoDesktop student
 cp -r gdx2d-helloDesktop student
 cp -r lib student
 cp gdx2d-library/gdx2d-desktop/target/*.jar student/lib
-sed -i 's/<!--STUDENT_RELEASE//g' student/pom.xml
-sed -i 's/STUDENT_RELEASE-->//g' student/pom.xml
+sed -e 's/<!--STUDENT_RELEASE//g' -e 's/STUDENT_RELEASE-->//g' student/pom.xml > student/pom.xml.tmp
+mv student/pom.xml.tmp student/pom.xml
+
+echo 'done :-)'


### PR DESCRIPTION
1. Updated LibGDX version from 1.9.8 to 1.12.0
2. Switched from LWJGL2 to LWJGL3 backend
3. Updated controllers API (replaced PovDirection enum with int values)
4. Fixed type casting for camera movement in tile demos
5. Updated Java requirements from 1.6 to 1.8
6. Added proper window resize handling in Game2D class
7. Maintained LWJGL2 support for Swing integration
8. Updated gdx-controllers dependency to the new separate package (2.2.2)
9. Removed deprecated GdxNativesLoader class
10. Improved student script with safer sed command usage
11. Wasted 45,390,848 tokens using Claude CLI, but it was not that bad

To make the application work in IntelliJ IDEA on macOS:

  1. Open your project in IntelliJ IDEA
  2. Click on "Run" in the top menu, then select "Edit Configurations..."
  3. Select your run configuration (or create a new one if needed)
  4. In the "VM options" field, add: -XstartOnFirstThread
  5. Make sure the "Main class" is set correctly (e.g., ch.hevs.gdx2d.demos.DemoSimpleAnimation)
  6. Click "Apply" and then "OK"
  7. Run your application using the updated configuration