### PR TITLE
fix: apply alpha on shape on MacOS

### DIFF
--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
@@ -196,6 +196,9 @@ public class GdxGraphics implements Disposable {
 				break;
 		}
 
+    Gdx.gl.glEnable(GL20.GL_BLEND);
+		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
 		switch (mode) {
 			case SHAPE_LINE:
 				shapeRenderer.begin(ShapeType.Line);


### PR DESCRIPTION
## Issue
When we render two shapes with an alpha less than 1, the transparency is correctly rendered. Homewever, when we add a picture, the transparency is no more rendered.

## Reproduce
> [!NOTE]
> I used the library on the `renaud:feature/upgrade_libgdx` branch to use the lib on MacOS

The code below can be used to reproduce the issue :

```scala
class AlphaRenderingWindow extends PortableApplication(800, 800) {
  override def onInit(): Unit = {
    setTitle("Alpha Rendering")
  }

  override def onGraphicRender(g: GdxGraphics): Unit = {
    g.clear(Colors.BACKGROUND)

    g.drawTransformedPicture(300, 300, 0, 1, new BitmapImage("data/hub.png"))

    g.drawFilledRectangle(300, 300, 200, 200, 0, new Color(0, 1, 0, 0.5F))
    g.drawFilledRectangle(400, 400, 200, 200, 0, new Color(0, 0, 1, 0.5F))
  }
}

object AlphaRendering extends App {
  new AlphaRenderingWindow().run()
}
```

## Disclaimer
I don't know if it's the correct way to fix this issue. I created this pull request to suggest a fix and to keep a track of this bug.