### PR TITLE
fix: render shape transparency when mixed with pictures

### DIFF
--- a/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
+++ b/gdx2d-library/gdx2d-core/src/main/java/ch/hevs/gdx2d/lib/GdxGraphics.java
@@ -196,6 +196,9 @@ public class GdxGraphics implements Disposable {
 				break;
 		}
 
+    Gdx.gl.glEnable(GL20.GL_BLEND);
+		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+
 		switch (mode) {
 			case SHAPE_LINE:
 				shapeRenderer.begin(ShapeType.Line);


### PR DESCRIPTION
## Issue
When we render two shapes with an alpha value less than 1, the transparency is rendered correctly. However, when we add an image, the transparency is no longer rendered

## Reproduction
The code below can be used to reproduce the problem:

```scala
class AlphaRenderingWindow extends PortableApplication(800, 800) {
  override def onInit(): Unit = {
    setTitle("Alpha Rendering")
  }

  override def onGraphicRender(g: GdxGraphics): Unit = {
    g.clear(Colors.BACKGROUND)

    g.drawTransformedPicture(300, 300, 0, 1, new BitmapImage("data/image.png"))

    g.drawFilledRectangle(300, 300, 200, 200, 0, new Color(0, 1, 0, 0.5F))
    g.drawFilledRectangle(400, 400, 200, 200, 0, new Color(0, 0, 1, 0.5F))
  }
}

object AlphaRendering extends App {
  new AlphaRenderingWindow()
}
```

## Disclaimer
I don't know if this is the right way to solve this problem. I created this pull request to suggest a fix and keep track of this bug.